### PR TITLE
Access-Control-Tokens.md: remove misleading sentence

### DIFF
--- a/docs/Tutorials/Access-Control-Tokens.md
+++ b/docs/Tutorials/Access-Control-Tokens.md
@@ -10,7 +10,7 @@ Tokens can be added and removed through the inspector:
 
 ![Receipt Trigger](../images/VoiceReceiptTrigger_Tokens.png)
 
-This receipt trigger will not function unless the local player has one of the two access tokens - 'TopSecretPassword' or 'mysocratesnote'. Tokens can also be managed with scripts:
+Tokens can also be managed with scripts:
 
 ```csharp
 var receiver = FindObjectOfType<VoiceReceiptTrigger>();


### PR DESCRIPTION
Remove sentence which says users must have one of two specific access tokens. There's no context for this and it could confuse new users. Perhaps it's left over from a previous example that was removed?