### PR TITLE
Update Licensing.md

### DIFF
--- a/docs/Basics/Licensing.md
+++ b/docs/Basics/Licensing.md
@@ -3,4 +3,4 @@
 Dissonances uses parts of the WebRTC project for audio preprocessing/postprocessing and the Opus codec for encoding/decoding audio. The distribution requirements for both of these projects are quite simple - you must include copies of the license in your project alongside `Opus.dll` and `AudioPluginDissonance.dll`:
 
  - [Opus License](https://opus-codec.org/license/)
- - [WebRTC License](https://webrtc.org/license/software/)
+ - [WebRTC License](https://webrtc.org/support/license/)


### PR DESCRIPTION
existing webRTC license link goes to a 404 - updated to valid license URL.