### PR TITLE
Update Windows dependency docs, add Steam notes.

### DIFF
--- a/docs/Platforms/Windows Desktop.md
+++ b/docs/Platforms/Windows Desktop.md
@@ -1,3 +1,5 @@
 # Windows (Desktop)
 
-To run Dissonance on a Windows PC requires [Visual Studio 2015 v140 Redist](https://www.microsoft.com/en-gb/download/details.aspx?id=48145). It's recommended that you package this with your application and install it as part of your install process.
+To run Dissonance on a Windows PC requires [Visual Studio 2019 Redist](https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019). It's recommended that you package this with your application and install it as part of your install process.
+
+When distributing over Steam, you set is as a dependency of your app in the Redistributables menu on the Steamwork panel to have it automatically installed.


### PR DESCRIPTION
Replaced the 2015 download link with a link to 2019 since the 2015 one was replaced by it.